### PR TITLE
Add support for smartstrip LEDs

### DIFF
--- a/hid-maschine-jam.c
+++ b/hid-maschine-jam.c
@@ -52,7 +52,7 @@ enum maschine_jam_midi_type{
 
 #define MASCHINE_JAM_NUMBER_BUTTON_LEDS 53
 #define MASCHINE_JAM_NUMBER_PAD_LEDS 80
-#define MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS 8
+#define MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS 88
 
 struct maschine_jam_midi_config {
 	enum maschine_jam_midi_type type;
@@ -113,7 +113,7 @@ struct maschine_jam_driver_data {
 	uint8_t					hid_report_led_pads[MASCHINE_JAM_NUMBER_PAD_LEDS];
 	spinlock_t				hid_report_led_pads_lock;
 	struct work_struct		hid_report_led_pads_work;
-	uint8_t					hid_report_led_strips[88];
+	uint8_t					hid_report_led_strips[MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS];
 	spinlock_t				hid_report_led_smartstrips_lock;
 	struct work_struct		hid_report_led_smartstrips_work;
 
@@ -219,7 +219,11 @@ static void maschine_jam_initialize_driver_data(struct maschine_jam_driver_data 
 		maschine_jam_output_mapping_add(&driver_data->midi_out_note_mapping[0][0], &driver_data->midi_out_pad_led_nodes[i]);
 	}
 	for(i=0;i<MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS;i++){
-		//??? SYSEX?
+		driver_data->midi_out_smartstrip_led_nodes[i].type = MJ_OUTPUT_SMARTSTRIP_LED_NODE;
+		driver_data->midi_out_smartstrip_led_nodes[i].index = i;
+		driver_data->midi_out_smartstrip_led_nodes[i].previous = NULL;
+		driver_data->midi_out_smartstrip_led_nodes[i].next = NULL;
+		maschine_jam_output_mapping_add(&driver_data->midi_out_note_mapping[0][0], &driver_data->midi_out_smartstrip_led_nodes[i]);
 	}
 	spin_lock_init(&driver_data->midi_out_mapping_lock);
 	memset(driver_data->hid_report_led_buttons, 0, sizeof(driver_data->hid_report_led_buttons));
@@ -413,6 +417,18 @@ static void maschine_jam_hid_write_led_pads_report(struct work_struct *work){
 	kfree(buffer);
 }
 static void maschine_jam_hid_write_led_smartstrips_report(struct work_struct *work){
+	int ret = 0;
+	struct maschine_jam_driver_data *driver_data = container_of(work, struct maschine_jam_driver_data, hid_report_led_smartstrips_work);
+	unsigned char *buffer;
+
+	buffer = kzalloc(MASCHINE_JAM_HID_REPORT_ID_BYTES + MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS, GFP_KERNEL);
+	buffer[0] = 0x82;
+	spin_lock(&driver_data->hid_report_led_smartstrips_lock);
+	memcpy(&buffer[MASCHINE_JAM_HID_REPORT_ID_BYTES], &driver_data->hid_report_led_strips, MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS);
+	spin_unlock(&driver_data->hid_report_led_smartstrips_lock);
+	ret = hid_hw_output_report(driver_data->mj_hid_device, buffer, MASCHINE_JAM_HID_REPORT_ID_BYTES + MASCHINE_JAM_NUMBER_SMARTSTRIP_LEDS);
+	//printk(KERN_NOTICE "maschine_jam_hid_write_report() - 0x82, ret=%d", ret);
+	kfree(buffer);
 }
 
 static int maschine_jam_write_snd_seq_event(struct maschine_jam_driver_data *driver_data, struct snd_seq_event* event){
@@ -423,12 +439,12 @@ static int maschine_jam_write_snd_seq_event(struct maschine_jam_driver_data *dri
 	spin_lock_irqsave(&driver_data->midi_in_decoder_lock, flags);
 	message_size = snd_midi_event_decode(driver_data->midi_in_decoder, buffer, MASCHINE_JAM_SYSEX_MAX_LENGTH, event);
 	spin_unlock_irqrestore(&driver_data->midi_in_decoder_lock, flags);
-	
+
 	if (message_size <= 0){
 		printk(KERN_ALERT "maschine_jam_write_snd_seq_event: message_size: %d <= 0\n", message_size);
 		return 0;
 	}
-	
+
 	if (driver_data->midi_in_substream != NULL){
 		spin_lock_irqsave(&driver_data->midi_in_lock, flags);
 		bytes_transmitted = snd_rawmidi_receive(driver_data->midi_in_substream, buffer, message_size);
@@ -443,7 +459,7 @@ static int maschine_jam_write_snd_seq_event(struct maschine_jam_driver_data *dri
 static int maschine_jam_write_midi_event(struct maschine_jam_driver_data *driver_data,
 	enum maschine_jam_midi_type midi_type, uint8_t channel, uint8_t key, uint8_t value){
 	struct snd_seq_event event;
-	
+
 	switch(midi_type){
 		case MJ_MIDI_TYPE_NOTE:
 			printk(KERN_NOTICE "maschine_jam_write_midi_event: noteon: %d %d %d\n", channel, key, value);
@@ -475,7 +491,7 @@ static int maschine_jam_write_midi_event(struct maschine_jam_driver_data *driver
 }
 static int maschine_jam_write_sysex_event(struct maschine_jam_driver_data *driver_data, unsigned char* message, uint8_t message_length){
 	struct snd_seq_event event;
-	
+
 	printk(KERN_NOTICE "maschine_jam_write_sysex_event: length: %d. message: %02X%02X%02X%02X\n", message_length, message[0], message[1], message[2], message[3]);
 	event.type = SNDRV_SEQ_EVENT_SYSEX;
 	event.flags = 0;
@@ -1315,6 +1331,8 @@ static ssize_t maschine_jam_outputs_type_show(struct kobject *kobj, struct kobj_
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		return scnprintf(buf, PAGE_SIZE, "maschine_jam_outputs_type_show: invalid io_attribute_type\n");
 	}
@@ -1355,6 +1373,8 @@ static ssize_t maschine_jam_outputs_type_store(struct kobject *kobj, struct kobj
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		printk(KERN_ALERT "maschine_jam_outputs_channel_store: invalid io_attribute_type\n");
 		return count;
@@ -1390,6 +1410,8 @@ static ssize_t maschine_jam_outputs_channel_show(struct kobject *kobj, struct ko
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		return scnprintf(buf, PAGE_SIZE, "maschine_jam_outputs_channel_show: invalid io_attribute_type\n");
 	}
@@ -1416,6 +1438,8 @@ static ssize_t maschine_jam_outputs_channel_store(struct kobject *kobj, struct k
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		printk(KERN_ALERT "maschine_jam_outputs_channel_store: invalid io_attribute_type\n");
 		return count;
@@ -1448,6 +1472,8 @@ static ssize_t maschine_jam_outputs_key_show(struct kobject *kobj, struct kobj_a
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		return scnprintf(buf, PAGE_SIZE, "maschine_jam_outputs_key_show: invalid io_attribute_type\n");
 	}
@@ -1474,6 +1500,8 @@ static ssize_t maschine_jam_outputs_key_store(struct kobject *kobj, struct kobj_
 		output_node = &driver_data->midi_out_button_led_nodes[io_attribute->io_index];
 	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_PAD){
 		output_node = &driver_data->midi_out_pad_led_nodes[io_attribute->io_index];
+	} else if (io_attribute->io_attribute_type == IO_ATTRIBUTE_LED_SMARTSTRIP) {
+		output_node = &driver_data->midi_out_smartstrip_led_nodes[io_attribute->io_index];
 	} else {
 		printk(KERN_ALERT "maschine_jam_outputs_key_store: invalid io_attribute_type\n");
 		return count;
@@ -1708,6 +1736,7 @@ MJ_OUTPUTS_BUTTON_ATTRIBUTE_GROUP(group_e, IO_ATTRIBUTE_LED_PAD, 76);
 MJ_OUTPUTS_BUTTON_ATTRIBUTE_GROUP(group_f, IO_ATTRIBUTE_LED_PAD, 77);
 MJ_OUTPUTS_BUTTON_ATTRIBUTE_GROUP(group_g, IO_ATTRIBUTE_LED_PAD, 78);
 MJ_OUTPUTS_BUTTON_ATTRIBUTE_GROUP(group_h, IO_ATTRIBUTE_LED_PAD, 79);
+
 static const struct attribute_group *maschine_jam_outputs_buttons_groups[] = {
 	&maschine_jam_outputs_button_song_group,
 	&maschine_jam_outputs_button_step_group,
@@ -1842,6 +1871,225 @@ static const struct attribute_group *maschine_jam_outputs_buttons_groups[] = {
 	&maschine_jam_outputs_button_group_f_group,
 	&maschine_jam_outputs_button_group_g_group,
 	&maschine_jam_outputs_button_group_h_group,
+	NULL
+};
+
+#define MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(_name, _io_attribute_type, _index) \
+	struct maschine_jam_io_attribute maschine_jam_outputs_smartstrip_ ## _name ## _attribute = { \
+		.type_attribute = { \
+			.attr = {.name = "type", .mode = MASCHINE_JAM_SYSFS_ATTRIBUTE_PERMISSIONS}, \
+			.show = maschine_jam_outputs_type_show, \
+			.store = maschine_jam_outputs_type_store, \
+		}, \
+		.channel_attribute = { \
+			.attr = {.name = "channel", .mode = MASCHINE_JAM_SYSFS_ATTRIBUTE_PERMISSIONS}, \
+			.show = maschine_jam_outputs_channel_show, \
+			.store = maschine_jam_outputs_channel_store, \
+		}, \
+		.key_attribute = { \
+			.attr = {.name = "key", .mode = MASCHINE_JAM_SYSFS_ATTRIBUTE_PERMISSIONS}, \
+			.show = maschine_jam_outputs_key_show, \
+			.store = maschine_jam_outputs_key_store, \
+		}, \
+		.status_attribute = { \
+			.attr = {.name = "status", .mode = MASCHINE_JAM_SYSFS_ATTRIBUTE_PERMISSIONS}, \
+			.show = maschine_jam_outputs_status_show, \
+			.store = maschine_jam_outputs_status_store, \
+		}, \
+		.io_attribute_type = _io_attribute_type, \
+		.io_index = _index, \
+		.smartstrip_finger = 0, \
+		.smartstrip_finger_mode = 0, \
+	}; \
+	static struct attribute *maschine_jam_outputs_smartstrip_ ## _name ## _attributes[] = { \
+		&maschine_jam_outputs_smartstrip_ ## _name ## _attribute.type_attribute.attr, \
+		&maschine_jam_outputs_smartstrip_ ## _name ## _attribute.channel_attribute.attr, \
+		&maschine_jam_outputs_smartstrip_ ## _name ## _attribute.key_attribute.attr, \
+		&maschine_jam_outputs_smartstrip_ ## _name ## _attribute.status_attribute.attr, \
+		NULL \
+	}; \
+	static const struct attribute_group maschine_jam_outputs_smartstrip_ ## _name ## _group = { \
+		.name = #_name, \
+		.attrs = maschine_jam_outputs_smartstrip_ ## _name ## _attributes, \
+	}
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 0);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 1);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 2);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 3);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 4);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 5);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 6);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 7);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 8);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 9);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_1x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 10);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 11);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 12);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 13);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 14);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 15);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 16);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 17);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 18);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 19);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 20);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_2x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 21);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 22);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 23);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 24);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 25);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 26);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 27);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 28);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 29);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 30);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 31);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_3x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 32);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 33);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 34);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 35);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 36);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 37);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 38);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 39);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 40);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 41);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 42);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_4x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 43);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 44);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 45);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 46);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 47);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 48);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 49);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 50);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 51);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 52);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 53);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_5x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 54);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 55);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 56);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 57);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 58);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 59);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 60);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 61);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 62);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 63);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 64);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_6x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 65);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 66);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 67);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 68);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 69);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 70);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 71);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 72);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 73);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 74);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 75);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_7x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 76);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x1, IO_ATTRIBUTE_LED_SMARTSTRIP, 77);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x2, IO_ATTRIBUTE_LED_SMARTSTRIP, 78);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x3, IO_ATTRIBUTE_LED_SMARTSTRIP, 79);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x4, IO_ATTRIBUTE_LED_SMARTSTRIP, 80);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x5, IO_ATTRIBUTE_LED_SMARTSTRIP, 81);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x6, IO_ATTRIBUTE_LED_SMARTSTRIP, 82);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x7, IO_ATTRIBUTE_LED_SMARTSTRIP, 83);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x8, IO_ATTRIBUTE_LED_SMARTSTRIP, 84);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x9, IO_ATTRIBUTE_LED_SMARTSTRIP, 85);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x10, IO_ATTRIBUTE_LED_SMARTSTRIP, 86);
+MJ_OUTPUTS_SMARTSTRIP_ATTRIBUTE_GROUP(led_8x11, IO_ATTRIBUTE_LED_SMARTSTRIP, 87);
+
+static const struct attribute_group *maschine_jam_outputs_smartstrips_groups[] = {
+	&maschine_jam_outputs_smartstrip_led_1x1_group,
+	&maschine_jam_outputs_smartstrip_led_1x2_group,
+	&maschine_jam_outputs_smartstrip_led_1x3_group,
+	&maschine_jam_outputs_smartstrip_led_1x4_group,
+	&maschine_jam_outputs_smartstrip_led_1x5_group,
+	&maschine_jam_outputs_smartstrip_led_1x6_group,
+	&maschine_jam_outputs_smartstrip_led_1x7_group,
+	&maschine_jam_outputs_smartstrip_led_1x8_group,
+	&maschine_jam_outputs_smartstrip_led_1x9_group,
+	&maschine_jam_outputs_smartstrip_led_1x10_group,
+	&maschine_jam_outputs_smartstrip_led_1x11_group,
+	&maschine_jam_outputs_smartstrip_led_2x1_group,
+	&maschine_jam_outputs_smartstrip_led_2x2_group,
+	&maschine_jam_outputs_smartstrip_led_2x3_group,
+	&maschine_jam_outputs_smartstrip_led_2x4_group,
+	&maschine_jam_outputs_smartstrip_led_2x5_group,
+	&maschine_jam_outputs_smartstrip_led_2x6_group,
+	&maschine_jam_outputs_smartstrip_led_2x7_group,
+	&maschine_jam_outputs_smartstrip_led_2x8_group,
+	&maschine_jam_outputs_smartstrip_led_2x9_group,
+	&maschine_jam_outputs_smartstrip_led_2x10_group,
+	&maschine_jam_outputs_smartstrip_led_2x11_group,
+	&maschine_jam_outputs_smartstrip_led_3x1_group,
+	&maschine_jam_outputs_smartstrip_led_3x2_group,
+	&maschine_jam_outputs_smartstrip_led_3x3_group,
+	&maschine_jam_outputs_smartstrip_led_3x4_group,
+	&maschine_jam_outputs_smartstrip_led_3x5_group,
+	&maschine_jam_outputs_smartstrip_led_3x6_group,
+	&maschine_jam_outputs_smartstrip_led_3x7_group,
+	&maschine_jam_outputs_smartstrip_led_3x8_group,
+	&maschine_jam_outputs_smartstrip_led_3x9_group,
+	&maschine_jam_outputs_smartstrip_led_3x10_group,
+	&maschine_jam_outputs_smartstrip_led_3x11_group,
+	&maschine_jam_outputs_smartstrip_led_4x1_group,
+	&maschine_jam_outputs_smartstrip_led_4x2_group,
+	&maschine_jam_outputs_smartstrip_led_4x3_group,
+	&maschine_jam_outputs_smartstrip_led_4x4_group,
+	&maschine_jam_outputs_smartstrip_led_4x5_group,
+	&maschine_jam_outputs_smartstrip_led_4x6_group,
+	&maschine_jam_outputs_smartstrip_led_4x7_group,
+	&maschine_jam_outputs_smartstrip_led_4x8_group,
+	&maschine_jam_outputs_smartstrip_led_4x9_group,
+	&maschine_jam_outputs_smartstrip_led_4x10_group,
+	&maschine_jam_outputs_smartstrip_led_4x11_group,
+	&maschine_jam_outputs_smartstrip_led_5x1_group,
+	&maschine_jam_outputs_smartstrip_led_5x2_group,
+	&maschine_jam_outputs_smartstrip_led_5x3_group,
+	&maschine_jam_outputs_smartstrip_led_5x4_group,
+	&maschine_jam_outputs_smartstrip_led_5x5_group,
+	&maschine_jam_outputs_smartstrip_led_5x6_group,
+	&maschine_jam_outputs_smartstrip_led_5x7_group,
+	&maschine_jam_outputs_smartstrip_led_5x8_group,
+	&maschine_jam_outputs_smartstrip_led_5x9_group,
+	&maschine_jam_outputs_smartstrip_led_5x10_group,
+	&maschine_jam_outputs_smartstrip_led_5x11_group,
+	&maschine_jam_outputs_smartstrip_led_6x1_group,
+	&maschine_jam_outputs_smartstrip_led_6x2_group,
+	&maschine_jam_outputs_smartstrip_led_6x3_group,
+	&maschine_jam_outputs_smartstrip_led_6x4_group,
+	&maschine_jam_outputs_smartstrip_led_6x5_group,
+	&maschine_jam_outputs_smartstrip_led_6x6_group,
+	&maschine_jam_outputs_smartstrip_led_6x7_group,
+	&maschine_jam_outputs_smartstrip_led_6x8_group,
+	&maschine_jam_outputs_smartstrip_led_6x9_group,
+	&maschine_jam_outputs_smartstrip_led_6x10_group,
+	&maschine_jam_outputs_smartstrip_led_6x11_group,
+	&maschine_jam_outputs_smartstrip_led_7x1_group,
+	&maschine_jam_outputs_smartstrip_led_7x2_group,
+	&maschine_jam_outputs_smartstrip_led_7x3_group,
+	&maschine_jam_outputs_smartstrip_led_7x4_group,
+	&maschine_jam_outputs_smartstrip_led_7x5_group,
+	&maschine_jam_outputs_smartstrip_led_7x6_group,
+	&maschine_jam_outputs_smartstrip_led_7x7_group,
+	&maschine_jam_outputs_smartstrip_led_7x8_group,
+	&maschine_jam_outputs_smartstrip_led_7x9_group,
+	&maschine_jam_outputs_smartstrip_led_7x10_group,
+	&maschine_jam_outputs_smartstrip_led_7x11_group,
+	&maschine_jam_outputs_smartstrip_led_8x1_group,
+	&maschine_jam_outputs_smartstrip_led_8x2_group,
+	&maschine_jam_outputs_smartstrip_led_8x3_group,
+	&maschine_jam_outputs_smartstrip_led_8x4_group,
+	&maschine_jam_outputs_smartstrip_led_8x5_group,
+	&maschine_jam_outputs_smartstrip_led_8x6_group,
+	&maschine_jam_outputs_smartstrip_led_8x7_group,
+	&maschine_jam_outputs_smartstrip_led_8x8_group,
+	&maschine_jam_outputs_smartstrip_led_8x9_group,
+	&maschine_jam_outputs_smartstrip_led_8x10_group,
+	&maschine_jam_outputs_smartstrip_led_8x11_group,
 	NULL
 };
 
@@ -1981,7 +2229,10 @@ static void maschine_jam_midi_out_trigger(struct snd_rawmidi_substream *substrea
 								spin_unlock(&driver_data->hid_report_led_pads_lock);
 								schedule_work(&driver_data->hid_report_led_pads_work);
 							}else if(output_node->type == MJ_OUTPUT_SMARTSTRIP_LED_NODE){
-								printk(KERN_NOTICE "snd_midi_event_encode: smartstrip node found\n");
+								spin_lock(&driver_data->hid_report_led_smartstrips_lock);
+								driver_data->hid_report_led_strips[output_node->index] = write_value;
+								spin_unlock(&driver_data->hid_report_led_smartstrips_lock);
+								schedule_work(&driver_data->hid_report_led_smartstrips_work);
 							}else{
 								printk(KERN_NOTICE "snd_midi_event_encode: invalid node type found\n");
 							}
@@ -2200,13 +2451,18 @@ static int maschine_jam_create_sysfs_outputs_interface(struct maschine_jam_drive
 		error_code = -1;
 		goto failure_remove_outputs_buttons_groups;
 	}
+	error_code = sysfs_create_groups(directory_outputs_smartstrips, maschine_jam_outputs_smartstrips_groups);
+	if (error_code < 0) {
+		printk(KERN_ALERT "sysfs_create_groups smartstrips failed!\n");
+		goto failure_delete_kobject_outputs_smartstrips;
+	}
 	driver_data->directory_outputs = directory_outputs;
 	driver_data->directory_outputs_buttons = directory_outputs_buttons;
 	driver_data->directory_outputs_smartstrips = directory_outputs_smartstrips;
 	goto return_error_code;
 
-//failure_delete_kobject_outputs_smartstrips:
-	//kobject_del(directory_outputs_smartstrips);
+failure_delete_kobject_outputs_smartstrips:
+	kobject_del(directory_outputs_smartstrips);
 failure_remove_outputs_buttons_groups:
 	sysfs_remove_groups(directory_outputs_buttons, maschine_jam_outputs_buttons_groups);
 failure_delete_kobject_outputs_buttons:

--- a/scripts/controller_mapping_bitwig.sh
+++ b/scripts/controller_mapping_bitwig.sh
@@ -5,7 +5,7 @@ set -e
 
 if [ $# -ne 1 ]; then
 	echo "Incorrect number of parameters."
-	echo "Usage: $(basename "$0") [Maschine Jam Sysfs Path]" 
+	echo "Usage: $(basename "$0") [Maschine Jam Sysfs Path]"
 	echo "Exiting now."
 	exit 1
 fi
@@ -20,7 +20,7 @@ fi
 midi_map_io(){
 	if [ $# -ne 4 ]; then
 		echo "Incorrect number of parameters."
-		echo "Usage: $(basename "$0") [sysfs directory] [channel] [type] [key]" 
+		echo "Usage: $(basename "$0") [sysfs directory] [channel] [type] [key]"
 		echo "Exiting now."
 		exit 1
 	fi
@@ -47,12 +47,12 @@ midi_map_io(){
 	echo "$IO_CHANNEL" > "${IO_DIRECTORY}/channel"
 	echo "$IO_TYPE" > "${IO_DIRECTORY}/type"
 	echo "$IO_KEY" > "${IO_DIRECTORY}/key"
-	
+
 	NAME="$(basename ${IO_DIRECTORY})"
 	UP_ONE="$(dirname "$IO_DIRECTORY")"
 	UP_TWO="$(dirname "$UP_ONE")"
 	echo "$(basename ${UP_TWO})/$(basename ${UP_ONE})/${NAME}: channel=${IO_CHANNEL}, type=${IO_TYPE}, key=${IO_KEY}"
-	
+
 	return 0
 }
 
@@ -68,7 +68,7 @@ midi_map_io(){
 			midi_map_io navigate_down 0 control_change 41
 			midi_map_io navigate_left 0 control_change 42
 			midi_map_io navigate_right 0 control_change 43
-			
+
 			midi_map_io scene_1 1 note 0
 			midi_map_io scene_2 1 note 1
 			midi_map_io scene_3 1 note 2
@@ -157,20 +157,20 @@ midi_map_io(){
 			midi_map_io encoder_push 0 control_change 87
 			midi_map_io encoder_touch 0 control_change 88
 			midi_map_io browse 0 control_change 44
-			
+
 			midi_map_io macro 0 control_change 90
 			midi_map_io level 0 control_change 91
 			midi_map_io aux 0 control_change 92
 			midi_map_io control 0 control_change 97
 			midi_map_io auto 0 control_change 98
-			
+
 			midi_map_io perform 0 control_change 45
 			midi_map_io notes 0 control_change 46
 			midi_map_io lock 0 control_change 47
 			midi_map_io tune 0 control_change 48
 			midi_map_io swing 0 control_change 49
 			midi_map_io select 0 control_change 80
-			
+
 			midi_map_io play 0 control_change 108
 			midi_map_io rec 0 control_change 109
 			midi_map_io page_left 0 control_change 107
@@ -192,7 +192,7 @@ midi_map_io(){
 			midi_map_io 6AS 0 control_change 13
 			midi_map_io 7AS 0 control_change 14
 			midi_map_io 8AS 0 control_change 15
-			
+
 			midi_map_io 1BS 0 control_change 16
 			midi_map_io 2BS 0 control_change 17
 			midi_map_io 3BS 0 control_change 18
@@ -220,20 +220,20 @@ midi_map_io(){
 			midi_map_io in_1 0 control_change 62
 			midi_map_io cue 0 control_change 63
 			midi_map_io browse 0 control_change 44
-			
+
 			midi_map_io macro 0 control_change 90
 			midi_map_io level 0 control_change 91
 			midi_map_io aux 0 control_change 92
 			midi_map_io control 0 control_change 97
 			midi_map_io auto 0 control_change 98
-			
+
 			midi_map_io perform 0 control_change 45
 			midi_map_io notes 0 control_change 46
 			midi_map_io lock 0 control_change 47
 			midi_map_io tune 0 control_change 48
 			midi_map_io swing 0 control_change 49
 			midi_map_io select 0 control_change 80
-			
+
 			midi_map_io play 0 control_change 108
 			midi_map_io rec 0 control_change 109
 			midi_map_io page_left 0 control_change 107
@@ -242,7 +242,7 @@ midi_map_io(){
 			midi_map_io grid 0 control_change 113
 			midi_map_io solo 0 control_change 111
 			midi_map_io mute 0 control_change 112
-			
+
 			midi_map_io level_left_1 0 control_change 8
 			midi_map_io level_left_2 0 control_change 9
 			midi_map_io level_left_3 0 control_change 10
@@ -259,7 +259,7 @@ midi_map_io(){
 			midi_map_io level_right_6 0 control_change 25
 			midi_map_io level_right_7 0 control_change 26
 			midi_map_io level_right_8 0 control_change 27
-			
+
 			midi_map_io scene_1 1 note 0
 			midi_map_io scene_2 1 note 1
 			midi_map_io scene_3 1 note 2
@@ -340,6 +340,17 @@ midi_map_io(){
 			midi_map_io matrix_8x6 0 note 83
 			midi_map_io matrix_8x7 0 note 84
 			midi_map_io matrix_8x8 0 note 85
+		)
+		(cd smartstrips
+			#purely for the purpose of testing!
+			midi_map_io led_1x1 0 control_change 38
+			midi_map_io led_1x11 0 control_change 39
+			midi_map_io led_4x1 0 note 82
+			midi_map_io led_4x11 0 note 83
+			midi_map_io led_5x4 0 note 84
+			midi_map_io led_5x6 0 note 85
+			midi_map_io led_8x1 0 control_change 8
+			midi_map_io led_8x11 0 control_change 9
 		)
 	)
 )


### PR DESCRIPTION
I've implemented basic support for mapping the smartstrip LEDs to MIDI. 
- Each of the 11 lights on every strip can be mapped individually.
- Color support should work exactly the same way as on the pad matrix.
- I've added some test mappings into the Bitwig script just to make sure it actually works as intended.